### PR TITLE
Fix deprecated PHP 7.4 Function ReflectionType::__toString()

### DIFF
--- a/src/Tsufeki/HmContainer/Wiring/Wiring.php
+++ b/src/Tsufeki/HmContainer/Wiring/Wiring.php
@@ -89,7 +89,7 @@ class Wiring
 
             $type = $param->getType();
             if ($type !== null && !$type->isBuiltin()) {
-                $arg->key = (string)$type;
+                $arg->key = $type instanceof \ReflectionNamedType ? $type->getName() : (string)$type;
             }
 
             $arguments[$param->getName()] = $arg;


### PR DESCRIPTION
Fix is what's suggested on https://www.php.net/manual/en/reflectionparameter.gettype.php

It checks for an updated interface, which should be compatible with PHP >= 7.0 as stated in composer.json

Optionally `$type->getName()` without instanceof check can be used, but then it will work on PHP >= 7.1.0